### PR TITLE
Bottom button styling issues on iphone SE

### DIFF
--- a/AppIntroSlider.js
+++ b/AppIntroSlider.js
@@ -200,7 +200,7 @@ const styles = StyleSheet.create({
     right: 0,
   },
   bottomButtonContainer: {
-    height: 44,
+    minHeight: 44,
     marginHorizontal: 16,
   },
   bottomButton: {


### PR DESCRIPTION
I have discovered that the text in the bottom button does not display in the centre due to the height of the button. So I have updated the property of the bottomButtonContainer style, changing height to minHeight to fix the issue.