### PR TITLE
fix first example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,13 @@ const slides = [
 ];
 
 export default class App extends React.Component {
-  this.state = {
-    showRealApp: false
+
+  constructor() {
+    super();
+    
+    this.state = {
+      showRealApp: false
+    }
   }
   _renderItem = (item) => {
     return (


### PR DESCRIPTION
well, title says it all
it should be either `state = {` (not `this.state`) or should be in the class `constructor`.