### PR TITLE
iOS offset on Orientation Change

### DIFF
--- a/AppIntroSlider.js
+++ b/AppIntroSlider.js
@@ -204,7 +204,7 @@ export default class AppIntroSlider extends React.Component {
           animated: false,
         });
       };
-      Platform.OS === 'android' ? setTimeout(func, 0) : func();
+      setTimeout(func, 0) : func();
     }
   };
 

--- a/AppIntroSlider.js
+++ b/AppIntroSlider.js
@@ -204,7 +204,7 @@ export default class AppIntroSlider extends React.Component {
           animated: false,
         });
       };
-      setTimeout(func, 0) : func();
+      setTimeout(func, 0);
     }
   };
 


### PR DESCRIPTION
If you change the orientation to landscape after the 2nd page on iOS, the offset is wrong.

Fixes https://github.com/Jacse/react-native-app-intro-slider/issues/5