### PR TITLE
Change slide key from number to string

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,21 @@ import AppIntroSlider from 'react-native-app-intro-slider';
 
 const slides = [
   {
-    key: 1,
+    key: 'one',
     title: 'Title 1',
     text: 'Description.\nSay something cool',
     image: require('./assets/1.jpg'),
     backgroundColor: '#59b2ab',
   },
   {
-    key: 2,
+    key: 'two',
     title: 'Title 2',
     text: 'Other cool stuff',
     image: require('./assets/2.jpg'),
     backgroundColor: '#febe29',
   },
   {
-    key: 3,
+    key: 'three',
     title: 'Rocket guy',
     text: 'I\'m already out of descriptions\n\nLorem ipsum bla bla bla',
     image: require('./assets/3.jpg'),


### PR DESCRIPTION
Prevents warning -> "Warning: Failed child context type: Invalid child context `virtualizedCell.cellKey` of type `number` supplied to `CellRenderer`, expected `string`. "  from Flatlist data attribute.
Avoids the warning for people copying code from the readme :)