### PR TITLE
add lazy props for screen rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ The component extends `FlatList` so all FlatList-props are valid.
 | renderPrevButton | `function` | renders a Text-component                     | Use to supply your own prev button . Has no effect if using `renderPagination`                                                                                                                                                              |
 | renderDoneButton | `function` | renders a Text-component                     | Use to supply your own done button. Has no effect if using `renderPagination`                                                                                                                                                               |
 | renderSkipButton | `function` | renders a Text-component                     | Use to supply your own skip button. Has no effect if using `renderPagination`                                                                                                                                                              |
+| lazy | `boolean` | false                     | Render single screen at a time if true (for optimization purpose)                                                                                                                                                              |
 
 ### Methods
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-app-intro-slider",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Simple and configurable app introduction slider for react native",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -312,7 +312,8 @@ export default class AppIntroSlider<ItemT = any> extends React.Component<
           extraData={extra}
           onLayout={this._onLayout}
           // make sure all slides are rendered so we can use dots to navigate to them
-          initialNumToRender={data.length}
+          initialNumToRender={this.props.lazy?1:data.length}
+          maxToRenderPerBatch={this.props.lazy?1:10}
           {...otherProps}
         />
         {renderPagination


### PR DESCRIPTION
Renders a single screen at a time if lazy={true} is passed in props , useful if there are many screens to be rendered .