### PR TITLE
Fixed an error on Configuring Button example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ export default class App extends React.Component {
     return (
       <AppIntroSlider
         data={slides}
+        renderItem={this._renderItem}
         renderDoneButton={this._renderDoneButton}
         renderNextButton={this._renderNextButton}
       />


### PR DESCRIPTION
There was a small error on the Configuring Button example on README.md. The `renderItem` prop was missing on the `<AppIntroSlider />` Component.